### PR TITLE
ディレクトリにあるZIPを一括処理するアルゴリズム

### DIFF
--- a/mojxml_plugin/algorithm.py
+++ b/mojxml_plugin/algorithm.py
@@ -192,3 +192,147 @@ class MOJXMLProcessingAlrogithm(QgsProcessingAlgorithm):
         return {
             self.OUTPUT: dest_id,
         }
+
+
+class MOJXMLProcessingAlrogithmDirectory(QgsProcessingAlgorithm):
+    """Processing algorithm for converting MOJXML-zipfile in a directory"""
+
+    INPUT = "INPUT"
+    OUTPUT = "OUTPUT"
+    INCLUDE_CHIKUGAI = "INCLUDE_CHIKUGAI"
+    INCLUDE_ARBITRARY_CRS = "INCLUDE_ARBITRARY_CRS"
+
+    def tr(self, string: str):
+        return QCoreApplication.translate("Processing", string)
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.INPUT,
+                self.tr("地図XML-ZIPが格納されたディレクトリ"),
+                behavior=QgsProcessingParameterFile.Folder,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterFeatureSink(
+                self.OUTPUT,
+                self.tr("出力レイヤ"),
+                QgsProcessing.TypeVectorPolygon,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterBoolean(
+                self.INCLUDE_ARBITRARY_CRS,
+                self.tr("任意座標系のデータを含める"),
+                defaultValue=False,
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterBoolean(
+                self.INCLUDE_CHIKUGAI,
+                self.tr("地区外・別図を含める"),
+                defaultValue=False,
+            )
+        )
+
+    def createInstance(self):
+        return MOJXMLProcessingAlrogithmDirectory()
+
+    def name(self):
+        return "mojxmlloaderdirectory"
+
+    def group(self):
+        return None
+
+    def groupId(self):
+        return None
+
+    def displayName(self):
+        return self.tr("フォルダから一括読み込み")
+
+    def shortHelpString(self) -> str:
+        return self.tr("法務省登記所備付地図データ（地図XML）をベクタレイヤに変換します。フォルダに存在する地図XML-ZIPを全て読み込みます。")
+
+    def processAlgorithm(self, parameters, context, feedback):
+        # Prepare field definition
+        fields = QgsFields()
+        for name, ogr_type in OGR_SCHEMA["properties"].items():
+            fields.append(QgsField(name, type=_OGR_QT_TYPE_MAP[ogr_type]))
+
+        # Input directory
+        dirname = self.parameterAsFile(parameters, self.INPUT, context)
+        if dirname is None:
+            raise QgsProcessingException(
+                self.invalidSourceError(parameters, self.INPUT)
+            )  # pragma: no cover
+
+        # Destination layer
+        (sink, dest_id) = self.parameterAsSink(
+            parameters,
+            self.OUTPUT,
+            context,
+            fields,
+            QgsWkbTypes.MultiPolygon,
+            QgsCoordinateReferenceSystem.fromEpsgId(4326),
+        )
+        if sink is None:
+            raise QgsProcessingException(
+                self.invalidSinkError(parameters, self.OUTPUT)
+            )  # pragma: no cover
+
+        # Some optional parameters
+        include_chikugai = self.parameterAsBoolean(
+            parameters, self.INCLUDE_CHIKUGAI, context
+        )
+        include_arbitrary = self.parameterAsBoolean(
+            parameters, self.INCLUDE_ARBITRARY_CRS, context
+        )
+
+        # Setup mojxml loader
+        po = ParseOptions(
+            include_arbitrary_crs=include_arbitrary,
+            include_chikugai=include_chikugai,
+        )
+        executor = ThreadPoolExecutor(po)
+        count = 0
+        feedback.pushInfo("地物を読み込んでいます...")
+        try:
+            for filename in Path(dirname).glob("*.zip"):
+                feedback.pushInfo(f"{filename.name} を読み込んでいます...")
+                for src_feat in files_to_feature_iter(
+                    [Path(filename) for filename in [filename]], executor
+                ):
+                    if feedback.isCanceled():
+                        return {}
+
+                    # Get the exterior ring and interior rings of the polygon
+                    json_geom = src_feat["geometry"]
+                    json_coords = json_geom["coordinates"]
+
+                    # Create a MultiPolygon feature
+                    geom = QgsMultiPolygon()
+                    exterior = json_coords[0][0]
+                    polygon = QgsPolygon(QgsLineString(exterior))
+                    for interior in json_coords[0][1:]:
+                        polygon.addInteriorRing(QgsLineString(interior))
+                    geom.addGeometry(polygon)
+                    feat = QgsFeature()
+                    feat.setGeometry(geom)
+                    feat.setFields(fields, initAttributes=True)
+                    for name, value in src_feat["properties"].items():
+                        feat.setAttribute(name, value)
+
+                    sink.addFeature(feat, QgsFeatureSink.FastInsert)
+
+                    count += 1
+                    if count % 100 == 0:
+                        feedback.pushInfo(f"{count} 個の地物を読み込みました。")
+        except ValueError:
+            feedback.reportError(
+                "ファイルの読み込みに失敗しました。正常なファイルかどうか確認してください。", fatalError=True
+            )
+
+        feedback.pushInfo(f"{count} 個の地物を読み込みました。")
+        return {
+            self.OUTPUT: dest_id,
+        }

--- a/mojxml_plugin/provider.py
+++ b/mojxml_plugin/provider.py
@@ -21,12 +21,13 @@ from pathlib import Path
 from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingProvider
 
-from .algorithm import MOJXMLProcessingAlrogithm
+from .algorithm import MOJXMLProcessingAlrogithm, MOJXMLProcessingAlrogithmDirectory
 
 
 class MOJXMLProcessingProvider(QgsProcessingProvider):
     def loadAlgorithms(self, *args, **kwargs):
         self.addAlgorithm(MOJXMLProcessingAlrogithm())
+        self.addAlgorithm(MOJXMLProcessingAlrogithmDirectory())
 
     def id(self, *args, **kwargs):
         return "mojxmlloader"


### PR DESCRIPTION
フォルダ内のZIPをまとめて処理できたら嬉しいなと思ったので、ちょっと書いてみました（既存の処理がロバストなので、ただglobでファイルを見つけているだけで動いた）。

既存のアルゴリズムで複数ファイル選択できたらよかったのですが、そういうオプションはなさそうでした（そもそも複数ファイルをインプットとできるようなクラスがなさそう）。
今の実装は既存アルゴリズムのコピペなので、処理系は関数化・共通化したいと思っています。

こんなことがやりたいなということでドラフトにしつつ、上記の件とテストを書いたらready for reviewにしようと思ってます。